### PR TITLE
Fixed AppVeyor build errors caused by restoring NuGet packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 1.0.{build}
+configuration: Release
+platform: Any CPU
+hosts:
+  api.nuget.org: 93.184.221.200
+cache:
+- InsireBot\packages -> InsireBot\**\packages.config
+before_build:
+- cmd: nuget restore InsireBot\Maple.sln
+build:
+  project: InsireBot\Maple.sln
+  verbosity: minimal
+artifacts:
+- path: 'InsireBot/InsireBot/bin/$(configuration)'
+  name: 'InsireBot-Binaries'


### PR DESCRIPTION
Also I made teprorary fix for connectivity issues to NuGet according to this [page](https://appveyor.statuspage.io/incidents/m2vdvw39kdk8).