### PR TITLE
Fix V3013

### DIFF
--- a/src/Maple/ViewModels/Navigation/Scenes.cs
+++ b/src/Maple/ViewModels/Navigation/Scenes.cs
@@ -177,7 +177,7 @@ namespace Maple
 
         private bool CanOpenMediaPlayerView()
         {
-            return Items?.Any(p => p.Content.GetType() == typeof(ColorOptionsPage)) == true;
+            return Items?.Any(p => p.Content.GetType() == typeof(MediaPlayerPage)) == true;
         }
 
         private void OpenGithubPage()


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- It is odd that the body of 'CanOpenColorOptionsView' function is fully equivalent to the body of 'CanOpenMediaPlayerView' function (168, line 178). Maple Scenes.cs 168