### PR TITLE
Fixed from PVS-Studio Static Analyzer

### DIFF
--- a/src/Maple.Core/Extensions/GenericExtensions.cs
+++ b/src/Maple.Core/Extensions/GenericExtensions.cs
@@ -9,7 +9,7 @@ namespace Maple.Core.Extensions
         public static T ThrowIfNull<T>(this T obj, string objName, [CallerMemberName]string callerName = null)
         {
             if (obj == null)
-                throw new ArgumentNullException(objName, string.Format("{0} {1} (2)", objName, Resources.IsRequired, callerName));
+                throw new ArgumentNullException(objName, string.Format("{0} {1} {2}", objName, Resources.IsRequired, callerName));
 
             return obj;
         }


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: callerName. Maple.Core GenericExtensions.cs 12